### PR TITLE
feat: add Swiss number formatting with apostrophes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { EvmBlockchain, type Asset, type EvmAsset } from "./types";
 import { useSearchParams } from "react-router-dom";
 import { useCurrencyPrice } from "./hooks/useCurrencyPrice";
 import { generateWalletBalancePDF } from "./utils/pdfGenerator";
+import { formatSwissNumber } from "./utils/formatNumber";
 
 type FormData = {
   date: string;
@@ -237,9 +238,9 @@ export default function App() {
                 </div>
                 {prices && (
                   <div className="mt-2">
-                    {selectedCurrency === "USD" && `≈ ${(parseFloat(balance) * prices.usd).toFixed(2)} USD`}
-                    {selectedCurrency === "EUR" && `≈ ${(parseFloat(balance) * prices.eur).toFixed(2)} EUR`}
-                    {selectedCurrency === "CHF" && `≈ ${(parseFloat(balance) * prices.chf).toFixed(2)} CHF`}
+                    {selectedCurrency === "USD" && `≈ ${formatSwissNumber(parseFloat(balance) * prices.usd)} USD`}
+                    {selectedCurrency === "EUR" && `≈ ${formatSwissNumber(parseFloat(balance) * prices.eur)} EUR`}
+                    {selectedCurrency === "CHF" && `≈ ${formatSwissNumber(parseFloat(balance) * prices.chf)} CHF`}
                   </div>
                 )}
               </div>

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -1,0 +1,16 @@
+/**
+ * Formats a number with Swiss-style thousands separators (apostrophes)
+ * @param value - The number to format
+ * @param decimals - Number of decimal places (default: 2)
+ * @returns Formatted string with apostrophes as thousands separators
+ */
+export function formatSwissNumber(value: number, decimals: number = 2): string {
+  // First, format with fixed decimals
+  const parts = value.toFixed(decimals).split('.');
+
+  // Add apostrophes as thousands separators
+  parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, "'");
+
+  // Join back with decimal point
+  return parts.join('.');
+}

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -1,5 +1,6 @@
 import jsPDF from "jspdf";
 import type { EvmAsset } from "../types";
+import { formatSwissNumber } from "./formatNumber";
 
 const hashAddress = async (address: string): Promise<string> => {
   const hashBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(address));
@@ -100,10 +101,10 @@ export const generateWalletBalancePDF = async ({
       if (prices) {
         const currencyValue =
           selectedCurrency === "USD"
-            ? `${(parseFloat(balance) * prices.usd).toFixed(2)}`
+            ? formatSwissNumber(parseFloat(balance) * prices.usd)
             : selectedCurrency === "EUR"
-            ? `${(parseFloat(balance) * prices.eur).toFixed(2)}`
-            : `${(parseFloat(balance) * prices.chf).toFixed(2)}`;
+            ? formatSwissNumber(parseFloat(balance) * prices.eur)
+            : formatSwissNumber(parseFloat(balance) * prices.chf);
 
         doc.text("In CHF:", labelX, dataStartY + 60);
         doc.text(currencyValue, valueX, dataStartY + 60);


### PR DESCRIPTION
## Summary
Implements Swiss-style number formatting with apostrophes as thousands separators for improved readability.

## Changes
- Created `formatSwissNumber` utility function for consistent number formatting
- Applied Swiss formatting to all currency displays in the UI
- Applied Swiss formatting to PDF generation
- Numbers now display as `1'000'000.00` instead of `1000000.00`

## Benefits
- Improved readability for large numbers
- Follows Swiss formatting conventions
- Consistent formatting across UI and PDF exports

## Testing
1. Enter a wallet with a large balance
2. Verify numbers display with apostrophes (e.g., `1'234'567.89`)
3. Check all three currencies (CHF, USD, EUR)
4. Generate PDF and verify formatting is consistent

## Screenshots
Before: `1000000.00 CHF`
After: `1'000'000.00 CHF`